### PR TITLE
fix: remove duplicate createPrismaClient function definition

### DIFF
--- a/packages/api/src/lib/prisma.ts
+++ b/packages/api/src/lib/prisma.ts
@@ -16,23 +16,6 @@ let connectionPromise: Promise<void> | null = null;
 function createPrismaClient(): PrismaClient {
   const client = new PrismaClient({
     datasourceUrl: env.database.url,
-    log: env.isProduction 
-      ? [
-          { emit: 'event', level: 'error' },
-          { emit: 'event', level: 'warn' },
-        ]
-      : env.isTest 
-        ? [] 
-        : ['error', 'warn'],
-    errorFormat: 'minimal',
-  });
-
-  return client;
-}
-
-function createPrismaClient(): PrismaClient {
-  const client = new PrismaClient({
-    datasourceUrl: env.database.url,
     log: env.isProduction
       ? [
           { emit: 'event', level: 'error' },


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
- TypeScript compilation failing with duplicate function implementation errors
- Docker builds failing in CI/CD pipeline due to duplicate createPrismaClient function definitions
- Frontend deployment blocked by backend build failures

### Root Cause
- Two identical createPrismaClient function definitions in packages/api/src/lib/prisma.ts
- Likely caused by merge conflict or copy-paste error during previous development

### Solution
- ✅ Removed duplicate function definition
- ✅ Maintained single implementation with proper error handling
- ✅ Preserved connection retry logic and graceful error handling
- ✅ Fixed TypeScript compilation errors

### Files Changed
- packages/api/src/lib/prisma.ts - Removed duplicate function (17 lines deleted)

### Testing
- ✅ Local TypeScript compilation: npm run build passes
- ✅ No breaking changes to existing functionality
- ✅ Maintains all existing Prisma client features

### Impact
- **Immediate**: Fixes Docker build failures in CI/CD
- **Deployment**: Unblocks frontend deployment process  
- **Code Quality**: Eliminates TypeScript compilation warnings

## 🚀 Ready for Review
This is a critical hotfix needed for deployment pipeline functionality.