### PR TITLE
Fix: Add CloudFormation stack stability check before deployment

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -84,6 +84,36 @@ jobs:
           aws secretsmanager get-secret-value --secret-id namecard/database/staging --region ${{ env.AWS_REGION }} --query 'SecretString' --output text > /dev/null
           echo "✅ All required secrets are accessible"
 
+      - name: Wait for stable CloudFormation stack
+        run: |
+          echo "🔍 Checking CloudFormation stack status before deployment..."
+          
+          STACK_STATUS=$(aws cloudformation describe-stacks --stack-name NameCardProd-staging --region ${{ env.AWS_REGION }} --query 'Stacks[0].StackStatus' --output text)
+          echo "Current stack status: $STACK_STATUS"
+          
+          if [[ "$STACK_STATUS" == *"IN_PROGRESS"* ]]; then
+            echo "⏳ Stack is in $STACK_STATUS state - waiting for completion..."
+            
+            # Wait for stack to reach stable state (max 20 minutes)
+            echo "⌛ Waiting for stack to reach stable state (max 20 minutes)..."
+            timeout 1200 aws cloudformation wait stack-update-complete --stack-name NameCardProd-staging --region ${{ env.AWS_REGION }} || {
+              echo "⚠️ Stack update didn't complete in 20 minutes, checking current status..."
+              FINAL_STATUS=$(aws cloudformation describe-stacks --stack-name NameCardProd-staging --region ${{ env.AWS_REGION }} --query 'Stacks[0].StackStatus' --output text)
+              echo "Final status: $FINAL_STATUS"
+              
+              if [[ "$FINAL_STATUS" == *"ROLLBACK_COMPLETE"* ]] || [[ "$FINAL_STATUS" == *"UPDATE_COMPLETE"* ]] || [[ "$FINAL_STATUS" == *"CREATE_COMPLETE"* ]]; then
+                echo "✅ Stack reached stable state: $FINAL_STATUS"
+              else
+                echo "❌ Stack is still in unstable state: $FINAL_STATUS"
+                echo "🔍 Recent stack events:"
+                aws cloudformation describe-stack-events --stack-name NameCardProd-staging --region ${{ env.AWS_REGION }} --query 'StackEvents[:5].[Timestamp,LogicalResourceId,ResourceStatus,ResourceStatusReason]' --output table
+                exit 1
+              fi
+            }
+          else
+            echo "✅ Stack is in stable state: $STACK_STATUS"
+          fi
+
       - name: Deploy infrastructure updates
         run: |
           cd infrastructure


### PR DESCRIPTION
## 🚨 Critical Issue: Stack in UPDATE_ROLLBACK_IN_PROGRESS State

**You were absolutely right\!** The CloudFormation stack is currently stuck in `UPDATE_ROLLBACK_IN_PROGRESS` state, which prevents any new deployments from proceeding.

**Current Stack Status:**
```
NameCardProd-staging: UPDATE_ROLLBACK_IN_PROGRESS
```

**Impact:**
- **GitHub Actions CDK deployments fail** - CloudFormation cannot update a stack in rollback state
- **PERPLEXITY_API_KEY fixes cannot be tested** until stack reaches stable state
- **All deployment attempts will fail** until rollback completes

## 🔍 Root Cause Analysis

From recent stack events:
```
2025-08-23T13:30:39.234000+00:00 | APIService8DA8F328 | UPDATE_FAILED | AWS::ECS::Service
2025-08-23T13:30:39.614000+00:00 | NameCardProd-staging | UPDATE_ROLLBACK_IN_PROGRESS | AWS::CloudFormation::Stack
```

**The ECS service update failed** (likely due to missing PERPLEXITY_API_KEY causing task startup failures), which triggered the rollback. However, the API secrets and task definition were updated successfully.

## 🛠️ Solution: Stack Stability Check

**Added comprehensive stack status verification before any CDK deployment:**

### ✅ **Pre-Deployment Stack Check**
```bash
STACK_STATUS=$(aws cloudformation describe-stacks --stack-name NameCardProd-staging --query 'Stacks[0].StackStatus' --output text)

if [[ "$STACK_STATUS" == *"IN_PROGRESS"* ]]; then
  # Wait for stack to reach stable state (max 20 minutes)
  aws cloudformation wait stack-update-complete --stack-name NameCardProd-staging
fi
```

### ✅ **Automatic Waiting**
- **Wait for Completion**: Automatically wait for rollback/update to finish
- **20-Minute Timeout**: Prevent infinite waiting  
- **Status Verification**: Accept stable states (ROLLBACK_COMPLETE, UPDATE_COMPLETE, CREATE_COMPLETE)

### ✅ **Enhanced Error Handling**
- **Progress Monitoring**: Show current stack status and wait progress
- **Timeout Handling**: Check final status if timeout occurs
- **Debug Information**: Show recent stack events if issues persist
- **Early Success**: Skip waiting if stack is already stable

## 🎯 Deployment Sequence

**With this fix, the deployment will:**
1. **Check Stack Status**: Verify CloudFormation stack state
2. **Wait if Needed**: Wait for UPDATE_ROLLBACK_IN_PROGRESS to complete → ROLLBACK_COMPLETE
3. **Proceed Safely**: Only start CDK deployment once stack is stable
4. **Apply PERPLEXITY_API_KEY Fixes**: Secret management fixes can now be properly tested

## 📋 Expected Timeline

**Current rollback should complete soon** based on stack events showing:
- API Secret update: ✅ Completed
- Task Definition update: ✅ Completed  
- ECS Service rollback: 🔄 In progress

Once rollback completes → ROLLBACK_COMPLETE, the PERPLEXITY_API_KEY fixes from PR #10 can be properly deployed and tested.

## 🚀 Next Steps

1. **Merge this PR** to add stack stability checking
2. **GitHub Actions will wait** for current rollback to complete
3. **Deploy PERPLEXITY_API_KEY fixes** once stack is stable
4. **Test ECS task success** with all required secrets present

**Thank you for catching this critical prerequisite\!** The stack must be stable before we can test the secret management fixes.

🎯 **This PR ensures deployments only proceed when CloudFormation stack is ready.**